### PR TITLE
Fix #5 - properly check for void_t implementation

### DIFF
--- a/premock.hpp
+++ b/premock.hpp
@@ -187,7 +187,7 @@ public:
 #        define PREMOCK_NEED_VOID_T
 #    endif
 #else
-#    if __cplusplus < 201703L  // look ma, standards!
+#    ifndef __cpp_lib_void_t
 #        define PREMOCK_NEED_VOID_T
 #    endif
 #endif


### PR DESCRIPTION
For clang and gcc the language feature macro` __cpp_lib_void_t` is defined
if a void_t implementation exists. The check works for both, `-std=c++14/17`
and `-std=gnu++14/17`.