### PR TITLE
Allow mocking of functions with reference parameters

### DIFF
--- a/premock.hpp
+++ b/premock.hpp
@@ -479,7 +479,7 @@ struct FunctionTraits<R(*)(A...)> {
      */
     template<int N>
     struct Arg {
-        using Type = std::remove_reference_t<decltype(std::get<N>(std::tuple<A...>()))>;
+        using Type = typename std::tuple_element<N, std::tuple<A...>>::type;
     };
 };
 

--- a/tests/test_traits.cpp
+++ b/tests/test_traits.cpp
@@ -11,11 +11,11 @@ TEST_CASE("StdFunctionTraits TupleType") {
 }
 
 
-int func(string, double, const char*);
+int func(string, double, const char*, int&, string&&);
 
 TEST_CASE("FunctionTraits std::function type") {
     static_assert(is_same<FunctionTraits<decltype(&func)>::StdFunctionType,
-                          function<int(string, double, const char*)>>::value, "Wrong std::function type");
+                          function<int(string, double, const char*, int&, string&&)>>::value, "Wrong std::function type");
 }
 
 
@@ -34,4 +34,10 @@ TEST_CASE("FunctionTraits parameter type") {
 
     static_assert(is_same<FunctionTraits<decltype(&func)>::Arg<2>::Type,
                           const char*>::value, "Wrong parameter type");
+                          
+    static_assert(is_same<FunctionTraits<decltype(&func)>::Arg<3>::Type,
+                          int&>::value, "Wrong parameter type");
+
+    static_assert(is_same<FunctionTraits<decltype(&func)>::Arg<4>::Type,
+                          string&&>::value, "Wrong parameter type");
 }


### PR DESCRIPTION
Hello, the code that deduces the type of a function argument does not support reference. Besides, a tuple with reference values cannot be default-constructed in this context without std::declval which makes it a bit more ugly.

In this PR this was all exchanged with a single std::tuple_element<> and unit tests were added to confirm that it works. 